### PR TITLE
feat: support both old pages and react app while we migrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && mkdir build_tmp && mv build/* build_tmp && cp -r docs/* build && mkdir build/questions && mv build_tmp/* build/questions && cp build/questions/index.html build/questions.html && rm -rf build_tmp",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "amplify:transformer": "FUNCTION_NAME=transformer scripts/compile-function.sh",


### PR DESCRIPTION
This one is super ugly but temporary.  The goal here is a quick and dirty way to maintain our current pages while concurrently hosting the new react version of the form.  The solution was to run the normal build script, put it in a subdirectory, and copy over our previously deployed directory.  Yes, I am indeed terrible at Bash and accept any and all improvements.