### PR TITLE
Add CA-specific questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hapi/joi": "^17.1.1",
     "aws-amplify": "^3.0.7",
     "aws-amplify-react": "^4.1.6",
+    "csv": "^5.3.2",
     "express": "^4.17.1",
     "grommet": "^2.12.0",
     "node-sass": "^4.13.1",

--- a/scripts/genform.js
+++ b/scripts/genform.js
@@ -126,7 +126,6 @@ function main() {
                     "results": {
                         "en": "Results"
                     }
-                }
             },
             pages: byPage.map(makePage)
         }
@@ -148,8 +147,9 @@ function main() {
                 }
 
                 let cond;
-                if (condition[0] === '<') {
-                    cond = {op: "lt", qid, value: condition.slice(1).trim()}
+                const LE = '<= '
+                if (condition.startsWith(LE)) {
+                    cond = {op: "le", qid, value: condition.slice(LE.length).trim()}
                 } else { // equals
                     cond = {op: "eq", qid, value: condition.toLowerCase()}
                 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,12 @@ function App() {
       <LanguageProvider>
         <Router>
           <Switch>
+            <Route exact path="/california">
+              <Landing ca={true} />
+            </Route>
+            <Route exact path="/california/questions">
+              <FormApp ca={true} />
+            </Route>
             <Route exact path="/questions">
               <FormApp />
             </Route>

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -109,6 +109,7 @@ const FormApp: React.FC<Props> = (props) => {
             </FormContext.Provider>
           </Card>
           <Sidebar
+            seal={ca ? seal : undefined}
             pages={pageTitles}
             currentIndex={currentIndex}
             setCurrentIndex={setNextPage}

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -18,15 +18,33 @@ interface FormValues {
   [questionId: string]: string;
 }
 
-const FormApp: React.FC<{}> = () => {
+interface Props {
+  ca?: boolean
+}
+
+const FormApp: React.FC<Props> = (props) => {
+
+  const { ca } = props
   const { language } = useContext(LanguageContext);
   const form = initializeForm();
 
   const { pages, seal } = form;
 
+  if (!ca) {
+    let rmPage = -1
+    pages.forEach((page, index) => {
+      if (page.title.en === 'California') {
+        rmPage = index
+      }
+    })
+    if (rmPage >= 0) {
+      pages.splice(rmPage, 1)
+    }
+  }
+
   const pageTitles = pages.map((page) => {
     return translate(page.title, language);
-  });
+  })
 
   const pageComponents = [...pages.map((page) => <Form page={page} />)];
 

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -8,7 +8,13 @@ import Footer from "./Footer";
 import "./footer.scss";
 import "./index.scss";
 
-function Landing() {
+interface Props {
+  ca?: boolean
+}
+
+const Landing : React.FC<Props> = (props) => {
+  const { ca } = props
+
   return (
     <div className="content-page">
       <Helmet>
@@ -46,7 +52,7 @@ function Landing() {
                   determine which financial relief programs you’re eligible for.
                 </p>
                 <p>Learn what you’ll need to prepare your loan applications.</p>
-                <Link to="/questions">
+                <Link to={ca ? "/california/questions" : "/questions"}>
                   <button className="usa-button usa-button--big">
                     Get Started
                   </button>

--- a/src/components/OldResults.tsx
+++ b/src/components/OldResults.tsx
@@ -64,12 +64,6 @@ const OldResults: React.FC = () => {
                         Federal SBA Debt Relief Program
                       </li>
                       <li
-                        className="sba_7a"
-                        data-program-name="SBA 7(a) Loan Program"
-                      >
-                        SBA 7(a) Loan Program
-                      </li>
-                      <li
                         className="ca_small_biz"
                         data-program-name="California Small Business Finance Center"
                       >
@@ -215,45 +209,6 @@ const OldResults: React.FC = () => {
                     </a>
                     <p className="yes-print">
                       Find a PPP lender near you:
-                      https://www.sba.gov/paycheckprotection/find
-                    </p>
-                  </div>
-                </div>
-
-                <div className="sba_7a program card">
-                  <div className="card-header">
-                    <h4>Federal 7(a) Loan</h4>
-                  </div>
-                  <div className="card-body">
-                    <dl className="row">
-                      <dt className="col-sm-3">What is it?</dt>
-                      <dd className="col-sm-9">
-                        A federal loan of up to $5 million. The Small Business
-                        Administration will guarantee 75–85% of the loan.
-                      </dd>
-
-                      <dt className="col-sm-3">What can I use it&nbsp;for?</dt>
-                      <dd className="col-sm-9">
-                        <ul>
-                          <li>Working capital</li>
-                          <li>Expanding, buying, or starting a business</li>
-                          <li>Buying or building real estate</li>
-                          <li>Refinancing your organization’s debt</li>
-                          <li>Buying equipment or inventory</li>
-                        </ul>
-                      </dd>
-                    </dl>
-                  </div>
-                  <div className="card-footer">
-                    <a
-                      href="https://www.sba.gov/paycheckprotection/find"
-                      className="no-print btn btn-primary"
-                      target="_blank"
-                    >
-                      Find a lender near you
-                    </a>
-                    <p className="yes-print">
-                      Find a lender near you:
                       https://www.sba.gov/paycheckprotection/find
                     </p>
                   </div>

--- a/src/components/ResultsButton.tsx
+++ b/src/components/ResultsButton.tsx
@@ -35,12 +35,12 @@ function evalRuleSet(values: Record<string, any>, ruleSet: Rule[]) {
     }
     if (op === "eq") {
       return inputValueAsString === value;
-    } else if (op === "lt") {
-      return inputValueAsString < value;
+    } else if (op === "le") {
+      return inputValueAsString <= value;
     } else {
       assert(false, `unknown op ${op}`);
     }
-  });
+  })
 }
 
 const ResultsButton: React.FC<{}> = (props) => {

--- a/src/form.json
+++ b/src/form.json
@@ -104,12 +104,13 @@
           "name": {
             "en": "When did your business begin operation?"
           },
-          "type": "datepicker"
+          "type": "datepicker",
+          "required": true
         },
         {
           "id": "employee_count",
           "name": {
-            "en": "Do you have:\n- 500 or less employees\n- meet the SBA industry size standard for small business (www.sba.gov/size-standards)"
+            "en": "Do you have:\n- 500 or less employees\n- or meet the SBA industry size standard for small business (www.sba.gov/size-standards)"
           },
           "type": "boolean",
           "required": true
@@ -118,40 +119,16 @@
     },
     {
       "title": {
-        "en": "Eligibility"
+        "en": "Eligability"
       },
       "heading": {
-        "en": "Eligibility"
+        "en": "Eligability"
       },
       "questions": [
         {
           "id": "is_illegal",
           "name": {
             "en": "Are you, your chief executive officer or the equivalent able to certify that (This question is to determine eligibility for Federal Small Business Administration EIDL) \n- The organization is not engaged in any illegal activity (as defined by Federal guidelines). \n- No principal of the organization with a 50 percent or greater ownership interest is more than sixty (60) days delinquent on child support obligations.\n- Applicant is not an agricultural enterprise (e.g., farm), other than an aquaculture enterprise, agricultural cooperative, or nursery. \n- The organization does not present live performances of a prurient sexual nature or derive directly or indirectly more than de minimis gross revenue through the sale of products or services, or the presentation of any depictions or displays, of a prurient sexual nature. \n- The organization is not in the business of lobbying \n- The organization cannot be a state, local, or municipal government entity and cannot be a member of Congress."
-          },
-          "type": "boolean",
-          "required": true
-        },
-        {
-          "id": "is_necessary_bc_of_economic_trouble",
-          "name": {
-            "en": "Does current economic uncertainty make the loan necessary to support your ongoing operations?"
-          },
-          "type": "boolean",
-          "required": true
-        },
-        {
-          "id": "will_be_used_for_employment",
-          "name": {
-            "en": "The funds will be used to retain workers and maintain payroll or to make mortgage, lease, and utility payments"
-          },
-          "type": "boolean",
-          "required": true
-        },
-        {
-          "id": "can_verify_numbers",
-          "name": {
-            "en": "You are able to provide documentation that verifies the number of full-time equivalent employees on payroll and the dollar amounts of payroll costs, covered mortgage interest payments, covered rent payments, and covered utilities."
           },
           "type": "boolean",
           "required": true
@@ -167,7 +144,7 @@
         {
           "id": "is_delinquent",
           "name": {
-            "en": "Has the Applicant, any owner of the Applicant, or any business owned or controlled by any of them, ever obtained a direct or\nguaranteed loan from SBA or any other Federal agency that is currently delinquent or has defaulted in the last 7 years and\ncaused a loss to the government?"
+            "en": "Has the Applicant, any owner of the Applicant, or any business owned or controlled by any of them, ever obtained a direct or\r\nguaranteed loan from SBA or any other Federal agency that is currently delinquent or has defaulted in the last 7 years and\r\ncaused a loss to the government?"
           },
           "type": "boolean",
           "required": true
@@ -175,7 +152,7 @@
         {
           "id": "is_criminal",
           "name": {
-            "en": "Is the Applicant (if an individual) or any individual owning 20% or more of the equity of the Applicant subject\nto an indictment, criminal information, arraignment, or other means by which formal criminal charges are\nbrought in any jurisdiction, or presently incarcerated, or on probation or parole?"
+            "en": "Is the Applicant (if an individual) or any individual owning 20% or more of the equity of the Applicant subject\r\nto an indictment, criminal information, arraignment, or other means by which formal criminal charges are\r\nbrought in any jurisdiction, or presently incarcerated, or on probation or parole?"
           },
           "type": "boolean",
           "required": true
@@ -183,7 +160,7 @@
         {
           "id": "is_felony",
           "name": {
-            "en": "Within the last 5 years, for any felony, has the Applicant (if an individual) or any owner of the Applicant 1)\nbeen convicted; 2) pleaded guilty; 3) pleaded nolo contendere; 4) been placed on pretrial diversion; or 5) been\nplaced on any form of parole or probation (including probation before judgment)?"
+            "en": "Within the last 5 years, for any felony, has the Applicant (if an individual) or any owner of the Applicant 1)\r\nbeen convicted; 2) pleaded guilty; 3) pleaded nolo contendere; 4) been placed on pretrial diversion; or 5) been\r\nplaced on any form of parole or probation (including probation before judgment)?"
           },
           "type": "boolean",
           "required": true
@@ -201,15 +178,33 @@
         {
           "id": "has_other_sba_loans",
           "name": {
-            "en": "Does your organization have any non-disaster SBA loans, in particular 7(a), 504, and/or microloans?"
+            "en": "Does your organization currently have any of the following SBA loans?\n- 7(a), 504, and/or microloans\n- SBA Disaster (Home or Business) Loans"
+          },
+          "type": "boolean",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": {
+        "en": "California"
+      },
+      "heading": {
+        "en": "California"
+      },
+      "questions": [
+        {
+          "id": "ca_legal_business",
+          "name": {
+            "en": "Is your business a legal business in the state of California?"
           },
           "type": "boolean",
           "required": true
         },
         {
-          "id": "has_other_sba_disaster_loans",
+          "id": "ca_employees",
           "name": {
-            "en": "Do you have any existing SBA Disaster (Home or Business) Loans?"
+            "en": "Does your business you have 750 or fewer employees?"
           },
           "type": "boolean",
           "required": true

--- a/src/rules.json
+++ b/src/rules.json
@@ -80,7 +80,7 @@
     ]
   },
   {
-    "program": "ca_sbfc",
+    "program": "ca_small_biz",
     "rules": [
       {
         "op": "eq",

--- a/src/rules.json
+++ b/src/rules.json
@@ -80,31 +80,6 @@
     ]
   },
   {
-    "program": "sba_7a",
-    "rules": [
-      {
-        "op": "eq",
-        "qid": "business_type",
-        "value": "must be for-profit"
-      },
-      {
-        "op": "eq",
-        "qid": "located_in_us",
-        "value": "true"
-      },
-      {
-        "op": "eq",
-        "qid": "is_illegal",
-        "value": "must be less than $5,000,000"
-      },
-      {
-        "op": "eq",
-        "qid": "has_other_sba_loans",
-        "value": "true"
-      }
-    ]
-  },
-  {
     "program": "ca_sbfc",
     "rules": [
       {

--- a/src/rules.json
+++ b/src/rules.json
@@ -8,28 +8,13 @@
         "value": "true"
       },
       {
-        "op": "lt",
+        "op": "le",
         "qid": "business_age",
         "value": "2020-01-31"
       },
       {
         "op": "eq",
         "qid": "employee_count",
-        "value": "true"
-      },
-      {
-        "op": "eq",
-        "qid": "is_illegal",
-        "value": "true"
-      }
-    ]
-  },
-  {
-    "program": "eidl_advance",
-    "rules": [
-      {
-        "op": "eq",
-        "qid": "located_in_us",
         "value": "true"
       },
       {
@@ -48,28 +33,13 @@
         "value": "true"
       },
       {
-        "op": "lt",
+        "op": "le",
         "qid": "business_age",
         "value": "2020-02-15"
       },
       {
         "op": "eq",
         "qid": "employee_count",
-        "value": "true"
-      },
-      {
-        "op": "eq",
-        "qid": "is_necessary_bc_of_economic_trouble",
-        "value": "true"
-      },
-      {
-        "op": "eq",
-        "qid": "will_be_used_for_employment",
-        "value": "true"
-      },
-      {
-        "op": "eq",
-        "qid": "can_verify_numbers",
         "value": "true"
       },
       {
@@ -106,10 +76,45 @@
         "op": "eq",
         "qid": "has_other_sba_loans",
         "value": "true"
+      }
+    ]
+  },
+  {
+    "program": "sba_7a",
+    "rules": [
+      {
+        "op": "eq",
+        "qid": "business_type",
+        "value": "must be for-profit"
       },
       {
         "op": "eq",
-        "qid": "has_other_sba_disaster_loans",
+        "qid": "located_in_us",
+        "value": "true"
+      },
+      {
+        "op": "eq",
+        "qid": "is_illegal",
+        "value": "must be less than $5,000,000"
+      },
+      {
+        "op": "eq",
+        "qid": "has_other_sba_loans",
+        "value": "true"
+      }
+    ]
+  },
+  {
+    "program": "ca_sbfc",
+    "rules": [
+      {
+        "op": "eq",
+        "qid": "ca_legal_business",
+        "value": "true"
+      },
+      {
+        "op": "eq",
+        "qid": "ca_employees",
         "value": "true"
       }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,6 +5275,31 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
+csv-generate@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-3.2.4.tgz#440dab9177339ee0676c9e5c16f50e2b3463c019"
+  integrity sha512-qNM9eqlxd53TWJeGtY1IQPj90b563Zx49eZs8e0uMyEvPgvNVmX1uZDtdzAcflB3PniuH9creAzcFOdyJ9YGvA==
+
+csv-parse@^4.8.8:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.9.0.tgz#a947c66d8ab31207f4933170064dd8268c511e99"
+  integrity sha512-SaFMvRWzobY9z0Nxg+q5pXvU2JY7p++icb1Bb/ZwGSLv058cLabhGg3YNpLPI2KALtZnoe/oNBCfWX9xgTkcaA==
+
+csv-stringify@^5.3.6:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.4.3.tgz#68f2e59652af7bb27bb06fe05a8237ff95bd13f9"
+  integrity sha512-WJLgRJQcVjPK45jXS1xfnkwVbw9bOjg2F2BQRa9OkG7Di2W/geclPZNlcQTwxbzn1nEDI2ane2AubTdTd6gCvw==
+
+csv@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/csv/-/csv-5.3.2.tgz#50b344e25dfbb8c62684a1bcec18c22468b2161e"
+  integrity sha512-odDyucr9OgJTdGM2wrMbJXbOkJx3nnUX3Pt8SFOwlAMOpsUQlz1dywvLMXJWX/4Ib0rjfOsaawuuwfI5ucqBGQ==
+  dependencies:
+    csv-generate "^3.2.4"
+    csv-parse "^4.8.8"
+    csv-stringify "^5.3.6"
+    stream-transform "^2.0.1"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -9414,6 +9439,11 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
+mixme@^0.3.1:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
+  integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
+
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -12804,6 +12834,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+stream-transform@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stream-transform/-/stream-transform-2.0.1.tgz#112ef2b4d8b9b517f9a6994b0bf7b946fa4d51bc"
+  integrity sha512-GiTcO/rRvZP2R8WPwxmxCFP+Of1yIATuFAmYkvSLDfcD93X2WHiPwdgIqeFT2CvL1gyAsjQvu1nB6RDNQ5b2jw==
+  dependencies:
+    mixme "^0.3.1"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
/ change less-than to less-than-or-equal in the rules evaluator, since
that's what we want.

/ fix some messed up stuff in genform.js, it looks like I didn't
commit some changes in the last round: add csv to our deps, fix a
syntax error (!?!)

/ Import the "Eligability V2 CA" spreadsheet, with some minor fixups.

/ Flip over to the React form; I was surpsised this isn't the default
was there something we're waiting on here?

/ Selectively enable the CA questions if were on /california, I'm not
sure if this is the best way but it was simple enough.