### PR TITLE
fix: Wrapping CA form with provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,9 @@ function App() {
               <Landing ca={true} />
             </Route>
             <Route exact path="/california/questions">
-              <FormApp ca={true} />
+              <FormProvider>
+                <FormApp ca={true} />
+              </FormProvider>
             </Route>
             <Route exact path="/questions">
               <FormProvider>

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -27,7 +27,7 @@ const FormApp: React.FC<Props> = (props) => {
   let filteredQuestions = questions;
   if (!ca) {
     // This is a temporary fix until we flush out branching better
-    filteredQuestions.filter((q) => !q.ca_only);
+    filteredQuestions = filteredQuestions.filter((q) => !q.ca_only);
   }
 
   const percent = Math.floor((currentIndex / filteredQuestions.length) * 100);


### PR DESCRIPTION
Test plan:
- [ ] Open the render link
- [ ] add `/california` to the url to get the CA landing page
- [ ] click the 'Get Started' button
- [ ] The form should load